### PR TITLE
New feature: mu4e-compose-signature

### DIFF
--- a/multimu4e.el
+++ b/multimu4e.el
@@ -41,6 +41,7 @@
     mu4e-sent-folder
     mu4e-sent-messages-behavior
     mu4e-drafts-folder
+    mu4e-compose-signature
     smtpmail-queue-dir
     smtpmail-local-domain
     smtpmail-smtp-user
@@ -180,6 +181,16 @@ If NAME or ADDRESS are not provided, use the variables `user-full-name' and
                     (or name user-full-name)
                     (or address user-mail-address)))))
 
+(defun multimu4e--change-signature-in-compose ()
+  "Change the signature of the current message."
+  (save-excursion
+    (set (make-local-variable 'message-signature) mu4e-compose-signature)
+    (message-goto-signature)
+    (message-beginning-of-line)
+    (previous-line 2)
+    (delete-region (point) (point-max))
+    (message-insert-signature)))
+
 ;;;###autoload
 (defun multimu4e-set-account-from-name (account-name)
   "Set all bindings of account named ACCOUNT-NAME."
@@ -190,7 +201,8 @@ If NAME or ADDRESS are not provided, use the variables `user-full-name' and
 Interactively, ask the user for the account to use."
   (interactive (list (multimu4e--choose-account)))
   (multimu4e-set-account account)
-  (multimu4e--change-from-in-compose))
+  (multimu4e--change-from-in-compose)
+  (multimu4e--change-signature-in-compose))
 
 (provide 'multimu4e)
 

--- a/test/multimu4e-tests.el
+++ b/test/multimu4e-tests.el
@@ -116,6 +116,35 @@
      "Was looking at %s"
      (buffer-substring-no-properties (point) (point-at-eol)))))
 
+(ert-deftest multimu4e-tests-change-signature-in-compose-with-newline ()
+  (with-current-buffer (get-buffer-create "*ert-multimu4el-w-newline*")
+    (insert "From: foo\n--text follows this line--\ncontent\n\n-- \nold signature")
+    (setq mu4e-compose-signature "new signature")
+    (multimu4e--change-signature-in-compose)
+    (message-goto-signature)
+    (previous-line 3)
+    (message-beginning-of-line)
+    (should (looking-at "content\n\n-- \nnew signature\n"))))
+
+(ert-deftest multimu4e-tests-change-signature-in-compose-without-newline ()
+  (with-current-buffer (get-buffer-create "*ert-multimu4el-wo-newline*")
+    (insert "From: foo\n--text follows this line--\ncontent\n-- \nold signature")
+    (setq mu4e-compose-signature "new signature")
+    (multimu4e--change-signature-in-compose)
+    (message-goto-signature)
+    (previous-line 2)
+    (message-beginning-of-line)
+    (should (looking-at "content\n-- \nnew signature\n"))))
+
+(ert-deftest multimu4e-tests-change-signature-in-compose-without-signature ()
+  (with-current-buffer (get-buffer-create "*ert-multimu4el-wo-signature*")
+    (insert "From: foo\n--text follows this line-- \ncontent")
+    (setq mu4e-compose-signature "new signature")
+    (multimu4e--change-signature-in-compose)
+    (message-goto-signature)
+    (message-beginning-of-line)
+    (should (looking-at "new signature"))))
+
 (provide 'multimu4e-tests)
 
 ;;; multimu4e-tests.el ends here


### PR DESCRIPTION
Add `mu4e-compose-signature` to `multimu4e--account-variables`. Add a
function that changes the signature of a message.
